### PR TITLE
feat: drop down, modal 컴포넌트 제작(#2)

### DIFF
--- a/src/assets/arrow_drop_down.svg
+++ b/src/assets/arrow_drop_down.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 15L7 10H17L12 15Z" fill="#1D1B20" style="fill:#1D1B20;fill:color(display-p3 0.1137 0.1059 0.1255);fill-opacity:1;"/>
+</svg>

--- a/src/assets/arrow_drop_up.svg
+++ b/src/assets/arrow_drop_up.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 14L12 9L17 14H7Z" fill="#1D1B20" style="fill:#1D1B20;fill:color(display-p3 0.1137 0.1059 0.1255);fill-opacity:1;"/>
+</svg>

--- a/src/components/common/dropdown/index.tsx
+++ b/src/components/common/dropdown/index.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import type { DropDownProps } from '@/types/commonUi';
+import ArrowDown from '@/assets/arrow_drop_down.svg?react';
+import ArrowUp from '@/assets/arrow_drop_up.svg?react';
+import styled from 'styled-components';
+import theme from '@/styles/theme';
+
+const DropDown = ({ placeholder, dropDownData, width }: DropDownProps) => {
+  const [view, setView] = useState<boolean>(false);
+  const [currentValue, setCurrentValue] = useState(placeholder);
+
+  const handleValue = (data: string) => {
+    setCurrentValue(data);
+    setView(!view);
+  };
+
+  return (
+    <S.DropDownContainer width={width}>
+      <S.DropDownBox
+        onClick={() => {
+          setView(!view);
+        }}>
+        {currentValue}
+        {view ? <ArrowUp /> : <ArrowDown />}
+      </S.DropDownBox>
+      {view && (
+        <S.DropDownList>
+          {dropDownData.map((data, index) => {
+            return (
+              <S.DropDownItem
+                key={index}
+                value={data}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleValue(data);
+                }}>
+                {data}
+              </S.DropDownItem>
+            );
+          })}
+        </S.DropDownList>
+      )}
+    </S.DropDownContainer>
+  );
+};
+
+export default DropDown;
+
+const S = {
+  DropDownContainer: styled.div<{ width?: string }>`
+    position: relative;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    flex-direction: column;
+    width: ${(props) => (props.width ? props.width : 'max-content')};
+    font-size: ${theme.fontSizes.fz20};
+    font-weight: ${theme.fontWeights.medium};
+  `,
+  DropDownBox: styled.div`
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    width: 100%;
+    padding: ${theme.spacing.xs};
+    border: ${theme.borderWidth.thin} solid ${theme.colors.black};
+    border-radius: ${theme.radius.small};
+  `,
+  DropDownList: styled.ul`
+    position: absolute;
+    left: 0;
+    top: 100%;
+    width: 100%;
+    margin-top: ${theme.spacing.xs};
+    padding: ${theme.spacing.xs};
+    border: ${theme.borderWidth.thin} solid ${theme.colors.black};
+    border-radius: ${theme.radius.small};
+    background-color: ${theme.colors.white};
+    shadow: ${theme.boxShadow.regular};
+  `,
+  DropDownItem: styled.li`
+    display: flex;
+    justify-content: center;
+    cursor: pointer;
+    list-style: none;
+    padding: ${theme.spacing.xs};
+  `,
+};

--- a/src/components/common/modal/index.tsx
+++ b/src/components/common/modal/index.tsx
@@ -1,0 +1,66 @@
+import theme from '@/styles/theme';
+import { ReactNode, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+const Modal = ({ children }: { children: ReactNode }) => {
+  const [modalOpen, setModalOpen] = useState(false);
+  const modalBackground = useRef<HTMLDivElement>(null);
+
+  return (
+    <>
+      <S.ModalOpenBtn onClick={() => setModalOpen(true)}>열기</S.ModalOpenBtn>
+
+      {modalOpen && (
+        <S.ModalContainer
+          ref={modalBackground}
+          onClick={(e) => {
+            if (e.target === modalBackground.current) {
+              setModalOpen(false);
+            }
+          }}>
+          <S.ModalContent>
+            {children}
+            <S.BtnWrapper>
+              <S.ModalCloseBtn onClick={() => setModalOpen(false)}>
+                닫기
+              </S.ModalCloseBtn>
+            </S.BtnWrapper>
+          </S.ModalContent>
+        </S.ModalContainer>
+      )}
+    </>
+  );
+};
+
+export default Modal;
+
+const S = {
+  BtnWrapper: styled.div`
+    display: flex;
+    justify-content: center;
+  `,
+  ModalCloseBtn: styled.button`
+    cursor: pointer;
+  `,
+  ModalOpenBtn: styled.button`
+    cursor: pointer;
+  `,
+  ModalContainer: styled.div`
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.5);
+  `,
+  ModalContent: styled.div`
+    background-color: ${theme.colors.white};
+    max-width: 70%;
+    max-height: 70%;
+    align-content: center;
+    padding: 15px;
+  `,
+};

--- a/src/types/commonUi.ts
+++ b/src/types/commonUi.ts
@@ -1,0 +1,7 @@
+type DropDownProps = {
+  placeholder: string;
+  dropDownData: string[];
+  width?: string;
+};
+
+export type { DropDownProps };


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #2 

## 🔎 작업 내용

### Drop Down
`placeholder`속성을 통해 초기에 선택되지 않았을 때 노출 될 문구를 지정 가능합니다.
`dropDownData` 속성은 문자열 배열을 통해 해당 dropdown에서 선택할 수 있는 리스트를 지정할 수 있습니다.
`width`는 지정하지 않을 경우 텍스트에 맞춰 길이가 지정되며, 선택적으로 값을 지정할 수 있습니다.

### Modal
열기 버튼을 통해 모달을 열고 닫기 버튼 또는 모달 밖을 클릭할 경우 모달이 닫히도록 개발했습니다.
`children`에 모달 내부에 표시할 컨텐츠를 전달할 수 있으며, 컴포넌트를 통해 해당 내용을 채울 수도 있습니다.
버튼의 경우 버튼 컴포넌트가 merge 되는 대로 수정하도록 하겠습니다.

## 💾 이미지 첨부

- ![image](https://github.com/user-attachments/assets/8f6f3c1a-42ac-4bdb-9c93-9540831cc9b9)

![image](https://github.com/user-attachments/assets/75f95f12-8107-45c8-bbe5-0e5a8ee2782a)


## 🔧 리뷰 요구사항

- 기타 추가 해야 할 기능이나, 수정이 필요한 사항에 대한 피드백은 언제나 환영입니다!
- dropdown의 up,down 이미지는 와이어 프레임 결과물에 따라 이미지 변경하도록 하겠습니다
