### PR TITLE
Feat/alert confirm

### DIFF
--- a/src/components/common/dialog/index.tsx
+++ b/src/components/common/dialog/index.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import useDialogStore from '@/store/useDialogStore';
+import styled from 'styled-components';
+
+const Dialog: React.FC = () => {
+  const {
+    isOpen,
+    desc,
+    onConfirm = () => {},
+    onCancel = () => {},
+    isConfirm,
+  } = useDialogStore();
+
+  const handleConfirm = () => {
+    onConfirm();
+  };
+
+  const handleCancel = () => {
+    onCancel();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <S.DialogBackDrop>
+      <S.DialogContainer>
+        <S.DialogDesc>{desc}</S.DialogDesc>
+        <S.DialogBtnWrap>
+          {isConfirm ? (
+            <S.DialogBtn onClick={handleCancel}>취소</S.DialogBtn>
+          ) : null}
+          <S.DialogBtn
+            $btnType={'confirm'}
+            onClick={handleConfirm}>
+            확인
+          </S.DialogBtn>
+        </S.DialogBtnWrap>
+      </S.DialogContainer>
+    </S.DialogBackDrop>
+  );
+};
+
+export default Dialog;
+
+const S = {
+  DialogBackDrop: styled.div`
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.3);
+  `,
+
+  DialogContainer: styled.div`
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 300px;
+    padding: 20px;
+    background: ${({ theme }) => theme.colors.white};
+    border-radius: ${({ theme }) => theme.radius.medium};
+  `,
+
+  DialogDesc: styled.div`
+    min-height: 30px;
+    margin-top: 10px;
+    text-align: center;
+  `,
+
+  DialogBtnWrap: styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 20px;
+  `,
+
+  DialogBtn: styled.button<{ $btnType?: string }>`
+    flex-grow: 1;
+    padding: 8px 0;
+
+    background: ${({ $btnType, theme }) =>
+      $btnType === 'confirm' ? theme.colors.primary : theme.colors.lightGray1};
+    border-radius: ${({ theme }) => theme.radius.xsmall};
+    color: ${({ $btnType, theme }) =>
+      $btnType === 'confirm' ? theme.colors.white : theme.colors.text};
+    text-align: center;
+    transition: all 0.3s ease-in-out;
+
+    &:hover {
+      opacity: 0.7;
+    }
+  `,
+};

--- a/src/components/common/dialog/index.tsx
+++ b/src/components/common/dialog/index.tsx
@@ -3,7 +3,7 @@ import useDialogStore from '@/store/useDialogStore';
 import styled from 'styled-components';
 
 const Dialog = () => {
-  const { isOpen, desc, onConfirm, onCancel, isConfirm } = useDialogStore();
+  const { isOpen, messages, onConfirm, onCancel, isConfirm } = useDialogStore();
 
   const ref = useRef<HTMLDivElement>(null);
 
@@ -40,7 +40,10 @@ const Dialog = () => {
       tabIndex={-1}
       ref={ref}>
       <S.DialogContainer>
-        <S.DialogDesc>{desc}</S.DialogDesc>
+        {messages.map((message, i) => (
+          <S.DialogDesc key={i}>{message}</S.DialogDesc>
+        ))}
+
         <S.DialogBtnWrap>
           {isConfirm && <S.DialogBtn onClick={handleCancel}>취소</S.DialogBtn>}
           <S.DialogBtn
@@ -74,15 +77,14 @@ const S = {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    width: 300px;
-    padding: 20px;
+    min-width: 300px;
+    max-width: 400px;
+    padding: 35px 20px 20px;
     background: ${({ theme }) => theme.colors.white};
     border-radius: ${({ theme }) => theme.radius.medium};
   `,
 
-  DialogDesc: styled.div`
-    min-height: 30px;
-    margin-top: 10px;
+  DialogDesc: styled.p`
     text-align: center;
   `,
 

--- a/src/components/common/dialog/index.tsx
+++ b/src/components/common/dialog/index.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import useDialogStore from '@/store/useDialogStore';
 import styled from 'styled-components';
 
-const Dialog: React.FC = () => {
+const Dialog = () => {
   const {
     isOpen,
     desc,
@@ -10,6 +10,8 @@ const Dialog: React.FC = () => {
     onCancel = () => {},
     isConfirm,
   } = useDialogStore();
+
+  const ref = useRef<HTMLDivElement>(null);
 
   const handleConfirm = () => {
     onConfirm();
@@ -19,16 +21,34 @@ const Dialog: React.FC = () => {
     onCancel();
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const key = e.key;
+    if (key === 'Enter') {
+      e.preventDefault();
+      onConfirm();
+    }
+    if (isConfirm && key === 'Escape') {
+      handleCancel();
+    }
+  };
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.focus();
+    }
+  }, [isOpen, isConfirm]);
+
   if (!isOpen) return null;
 
   return (
-    <S.DialogBackDrop>
+    <S.DialogBackDrop
+      onKeyDown={handleKeyDown}
+      tabIndex={-1}
+      ref={ref}>
       <S.DialogContainer>
         <S.DialogDesc>{desc}</S.DialogDesc>
         <S.DialogBtnWrap>
-          {isConfirm ? (
-            <S.DialogBtn onClick={handleCancel}>취소</S.DialogBtn>
-          ) : null}
+          {isConfirm && <S.DialogBtn onClick={handleCancel}>취소</S.DialogBtn>}
           <S.DialogBtn
             $btnType={'confirm'}
             onClick={handleConfirm}>

--- a/src/components/common/dialog/index.tsx
+++ b/src/components/common/dialog/index.tsx
@@ -3,13 +3,7 @@ import useDialogStore from '@/store/useDialogStore';
 import styled from 'styled-components';
 
 const Dialog = () => {
-  const {
-    isOpen,
-    desc,
-    onConfirm = () => {},
-    onCancel = () => {},
-    isConfirm,
-  } = useDialogStore();
+  const { isOpen, desc, onConfirm, onCancel, isConfirm } = useDialogStore();
 
   const ref = useRef<HTMLDivElement>(null);
 

--- a/src/hook/useDialog.ts
+++ b/src/hook/useDialog.ts
@@ -1,14 +1,15 @@
 import useDialogStore from '@/store/useDialogStore';
+import React from 'react';
 
 export const useDialog = () => {
   const openAlert = useDialogStore((state) => state.openAlert);
   const openConfirm = useDialogStore((state) => state.openConfirm);
 
-  const alert = (desc: string) => {
+  const alert = (desc: React.ReactNode) => {
     openAlert(desc);
   };
 
-  const confirm = async (desc: string) => {
+  const confirm = async (desc: React.ReactNode) => {
     return await openConfirm(desc);
   };
 

--- a/src/hook/useDialog.ts
+++ b/src/hook/useDialog.ts
@@ -1,0 +1,16 @@
+import useDialogStore from '@/store/useDialogStore';
+
+export const useDialog = () => {
+  const openAlert = useDialogStore((state) => state.openAlert);
+  const openConfirm = useDialogStore((state) => state.openConfirm);
+
+  const alert = (message: string) => {
+    openAlert(message);
+  };
+
+  const confirm = async (message: string) => {
+    return await openConfirm(message);
+  };
+
+  return { alert, confirm };
+};

--- a/src/hook/useDialog.ts
+++ b/src/hook/useDialog.ts
@@ -1,16 +1,15 @@
 import useDialogStore from '@/store/useDialogStore';
-import React from 'react';
 
 export const useDialog = () => {
   const openAlert = useDialogStore((state) => state.openAlert);
   const openConfirm = useDialogStore((state) => state.openConfirm);
 
-  const alert = (desc: React.ReactNode) => {
-    openAlert(desc);
+  const alert = (...messages: string[]) => {
+    openAlert(messages);
   };
 
-  const confirm = async (desc: React.ReactNode) => {
-    return await openConfirm(desc);
+  const confirm = async (...messages: string[]) => {
+    return await openConfirm(messages);
   };
 
   return { alert, confirm };

--- a/src/hook/useDialog.ts
+++ b/src/hook/useDialog.ts
@@ -4,12 +4,12 @@ export const useDialog = () => {
   const openAlert = useDialogStore((state) => state.openAlert);
   const openConfirm = useDialogStore((state) => state.openConfirm);
 
-  const alert = (message: string) => {
-    openAlert(message);
+  const alert = (desc: string) => {
+    openAlert(desc);
   };
 
-  const confirm = async (message: string) => {
-    return await openConfirm(message);
+  const confirm = async (desc: string) => {
+    return await openConfirm(desc);
   };
 
   return { alert, confirm };

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
 import GlobalStyles from '@/styles/GlobalStyles';
 import { ThemeProvider } from 'styled-components';
 import theme from '@/styles/theme';
+import Dialog from '@/components/common/dialog';
 
 // 임시 로그인 상태
 const isAuthenticated = false;
@@ -29,6 +30,7 @@ function RootComponent() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyles />
+      <Dialog />
       <Outlet />
     </ThemeProvider>
   );

--- a/src/store/useDialogStore.ts
+++ b/src/store/useDialogStore.ts
@@ -1,36 +1,36 @@
 import { create } from 'zustand';
-import React from 'react';
 
 interface DialogState {
   isOpen: boolean;
   isConfirm: boolean;
-  desc: React.ReactNode;
+  messages: string[];
   onConfirm: () => void;
   onCancel: () => void;
 
   /* eslint-disable no-unused-vars */
-  openAlert: (desc: React.ReactNode) => void;
-  openConfirm: (desc: React.ReactNode) => Promise<boolean>;
+
+  openAlert: (messages: string[]) => void;
+  openConfirm: (messages: string[]) => Promise<boolean>;
   closeDialog: () => void;
 }
 
 const useDialogStore = create<DialogState>((set) => ({
   isOpen: false,
   isConfirm: false,
-  desc: '',
+  messages: [],
   onConfirm: () => {},
   onCancel: () => {},
 
-  openAlert: (desc: React.ReactNode) => {
-    set({ isOpen: true, isConfirm: false, desc: desc });
+  openAlert: (messages: string[]) => {
+    set({ isOpen: true, isConfirm: false, messages: messages });
   },
 
-  openConfirm: (desc: React.ReactNode) => {
+  openConfirm: (messages: string[]) => {
     return new Promise((resolve) => {
       set({
         isOpen: true,
         isConfirm: true,
-        desc: desc,
+        messages: messages,
         onConfirm: () => {
           resolve(true);
           set({ isOpen: false });
@@ -44,7 +44,12 @@ const useDialogStore = create<DialogState>((set) => ({
   },
 
   closeDialog: () =>
-    set({ isOpen: false, desc: '', onConfirm: () => {}, onCancel: () => {} }),
+    set({
+      isOpen: false,
+      messages: [],
+      onConfirm: () => {},
+      onCancel: () => {},
+    }),
 }));
 
 export default useDialogStore;

--- a/src/store/useDialogStore.ts
+++ b/src/store/useDialogStore.ts
@@ -1,15 +1,16 @@
 import { create } from 'zustand';
+import React from 'react';
 
 interface DialogState {
   isOpen: boolean;
   isConfirm: boolean;
-  desc: string;
+  desc: React.ReactNode;
   onConfirm: () => void;
   onCancel: () => void;
 
   /* eslint-disable no-unused-vars */
-  openAlert: (desc: string) => void;
-  openConfirm: (desc: string) => Promise<boolean>;
+  openAlert: (desc: React.ReactNode) => void;
+  openConfirm: (desc: React.ReactNode) => Promise<boolean>;
   closeDialog: () => void;
 }
 
@@ -20,11 +21,11 @@ const useDialogStore = create<DialogState>((set) => ({
   onConfirm: () => {},
   onCancel: () => {},
 
-  openAlert: (desc: string) => {
+  openAlert: (desc: React.ReactNode) => {
     set({ isOpen: true, isConfirm: false, desc: desc });
   },
 
-  openConfirm: (desc: string) => {
+  openConfirm: (desc: React.ReactNode) => {
     return new Promise((resolve) => {
       set({
         isOpen: true,

--- a/src/store/useDialogStore.ts
+++ b/src/store/useDialogStore.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+
+interface DialogState {
+  isOpen: boolean;
+  isConfirm: boolean;
+  desc: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+
+  /* eslint-disable no-unused-vars */
+  openAlert: (desc: string) => void;
+  openConfirm: (desc: string) => Promise<boolean>;
+  closeDialog: () => void;
+}
+
+const useDialogStore = create<DialogState>((set) => ({
+  isOpen: false,
+  isConfirm: false,
+  desc: '',
+  onConfirm: () => {},
+  onCancel: () => {},
+
+  openAlert: (desc: string) => {
+    set({ isOpen: true, isConfirm: false, desc: desc });
+  },
+
+  openConfirm: (desc: string) => {
+    return new Promise((resolve) => {
+      set({
+        isOpen: true,
+        isConfirm: true,
+        desc: desc,
+        onConfirm: () => {
+          resolve(true);
+          set({ isOpen: false });
+        },
+        onCancel: () => {
+          resolve(false);
+          set({ isOpen: false });
+        },
+      });
+    });
+  },
+
+  closeDialog: () =>
+    set({ isOpen: false, desc: '', onConfirm: () => {}, onCancel: () => {} }),
+}));
+
+export default useDialogStore;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -15,9 +15,21 @@ const GlobalStyles = createGlobalStyle`
 
     body,html {
     font-family: "NexonLv2", "Malgun Gothic", "맑은 고딕", helvetica, sans-serif;
-    font-size: ${({ theme }) => theme.fontSizes.fz58};
+    font-size: ${({ theme }) => theme.fontSizes.fz16};
     color: ${({ theme }) => theme.colors.text};
-    font-weight: ${({ theme }) => theme.fontWeights.regular}
+    line-height: ${({ theme }) => theme.lineHeights.small};
+    font-weight: ${({ theme }) => theme.fontWeights.regular};
+    }
+
+    div, p, h1, h2, h3, h4, h5, h6{
+    box-sizing: border-box;
+    }
+
+    button {
+    border:none;
+    background:none;
+    font-size: inherit;
+    cursor: pointer;
     }
 
 `;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -63,13 +63,14 @@ const theme = {
 
   // line-heights
   lineHeights: {
-    small: '1.2',
+    small: '1.3',
     medium: '1.5',
     large: '1.8',
   },
 
   // radius
   radius: {
+    xsmall: '4px',
     small: '6px',
     medium: '8px',
     large: '10px',


### PR DESCRIPTION
## ➕ 이슈 링크

- 이슈 넘버 #9 
-

## 🔎 작업 내용

- 전역적으로 사용할 수 있는 alert와 confirm 훅을  커스텀하여 구현했습니다.
- 사용자의 응답 대기를 위해 confirm은 비동기적으로 처리하였습니다. 
- 키다운 이벤트를 활용하여 사용자 경험을 개선하였습니다.
- 메세지는 배열로 처리하여 개행처리할 수 있도록 했습니다. 개행 처리가 필요한 Dialog 같은 경우에는 배열로 작성해주시면 됩니다. 

## 💾 이미지 첨부
- useDialog 사용 방법 1.

```
import { useDialog } from '@/hook/useDialog';

function RouteComponent() {
  const { alert, confirm } = useDialog();

// ✅ Confirm 사용 방법
  const handleConfirmTest = async () => {
    const isConfirmed = await confirm('저장하시겠습니까?');
    if (isConfirmed) {
      // 저장로직
      alert('저장되었습니다.');
    } else {
      // 취소로직
    }
  };

// ✅ Alert 사용 방법
  const handleAlertTest = () => {
    alert('저장되었습니다.');
  };
  
  return (
    <div>
      <button onClick={handleConfirmTest}>confirm</button>
      <button onClick={handleAlertTest}>alert</button>
    </div>
  );
}
```

-  useDialog 사용 방법 2. (개행이 필요한 경우)
```
import { useDialog } from '@/hook/useDialog';

function RouteComponent() {
  const { confirm } = useDialog();

// ✅  개행 메세지가 적용된 Confirm 사용 방법
  const handleConfirmTest = async () => {
    const isConfirmed = await confirm( '취소하시겠습니까?',  '현재까지 작성한 내용이 모두 취소됩니다.');
    if (isConfirmed) {
      // 저장로직
      alert('취소되었습니다.');
    } else {
      // 취소로직
    }
  };

  
  return (
    <div>
      <button onClick={handleConfirmTest}>confirm</button>
    </div>
  );
}
```


<img width="1512" alt="스크린샷 2025-03-09 오후 8 10 54" src="https://github.com/user-attachments/assets/818aafb4-913a-4b71-8fbb-9b31e496b5bd" />

<img width="1511" alt="스크린샷 2025-03-09 오후 8 11 18" src="https://github.com/user-attachments/assets/20fc4172-6332-459f-be96-7c39ec98ab63" />

<img width="1511" alt="스크린샷 2025-03-09 오후 9 26 35" src="https://github.com/user-attachments/assets/251ffa0b-38e5-4e19-adda-a9817ad69177" />
## 🔧 리뷰 

요구사항



